### PR TITLE
Issue/20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## UNDEFINED
+- [Added setOnEditActionDone method to EmeraldBaseEditText][issue-20]
+
 ## 0.2.0 - 2018-09-06
 - [Added LifecycleOwnerConstraintLayout][issue-14]
 
@@ -12,3 +15,4 @@
 - Initial release
 
 [issue-14]:https://github.com/stone-payments/emerald-components-android/issues/14
+[issue-20]:https://github.com/stone-payments/emerald-components-android/issues/20

--- a/app/src/main/java/br/com/stone/emeraldcomponentsandroid/activities/EditTextActivity.kt
+++ b/app/src/main/java/br/com/stone/emeraldcomponentsandroid/activities/EditTextActivity.kt
@@ -3,6 +3,7 @@ package br.com.stone.emeraldcomponentsandroid.activities
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
+import android.widget.Toast
 import br.com.stone.emeraldcomponentsandroid.R
 import kotlinx.android.synthetic.main.activity_emerald_edittext.*
 
@@ -22,6 +23,10 @@ class EditTextActivity : AppCompatActivity() {
         checkBox.isChecked = emeraldEditText.required
         checkBox.setOnCheckedChangeListener{ _, checked ->
             emeraldEditText.required = checked
+        }
+
+        editText.setOnEditorActionDone {
+            Toast.makeText(this,"keyboard done clicked",Toast.LENGTH_SHORT).show()
         }
 
         button2.setOnClickListener {

--- a/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/input/EmeraldBaseEditText.kt
+++ b/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/input/EmeraldBaseEditText.kt
@@ -102,4 +102,18 @@ abstract class EmeraldBaseEditText : TextInputLayout, SelfValidatorField {
     }
 
     abstract fun validateEditText(): Pair<Boolean, String>
+
+    fun setOnEditorActionDone(action: () -> Unit) {
+        editText?.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
+                EditorInfo.IME_ACTION_DONE -> {
+                    action()
+                    true
+                }
+                else -> {
+                    false
+                }
+            }
+        }
+    }
 }

--- a/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
+++ b/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
@@ -2,6 +2,7 @@ package br.com.stone.emeraldcomponents.basics.input
 
 import android.support.v4.app.FragmentActivity
 import android.util.AttributeSet
+import android.view.inputmethod.EditorInfo
 import br.com.stone.emeraldcomponents.R
 import br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
 import org.junit.Assert.assertEquals
@@ -105,5 +106,14 @@ class EmeraldEditTextTest {
         view.required = false
         view.text = ""
         assertTrue(view.isValid())
+    }
+
+    @Test
+    fun testNotRd() {
+        var x = 0
+        view.editText?.imeOptions = EditorInfo.IME_ACTION_DONE
+        view.setOnEditorActionDone { x = 1 }
+        view.editText?.onEditorAction(EditorInfo.IME_ACTION_DONE)
+        assertEquals(1, x)
     }
 }

--- a/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
+++ b/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
@@ -110,10 +110,11 @@ class EmeraldEditTextTest {
 
     @Test
     fun testOnEditActionDoneMethod() {
-        var shouldBeOne = 0
+        val expectedResult = true
+        var actualResult = false
         view.editText?.imeOptions = EditorInfo.IME_ACTION_DONE
-        view.setOnEditorActionDone { shouldBeOne = 1 }
+        view.setOnEditorActionDone { actualResult = expectedResult }
         view.editText?.onEditorAction(EditorInfo.IME_ACTION_DONE)
-        assertEquals(1, shouldBeOne)
+        assertEquals(expectedResult, actualResult)
     }
 }

--- a/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
+++ b/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
@@ -110,11 +110,11 @@ class EmeraldEditTextTest {
 
     @Test
     fun testOnEditActionDoneMethod() {
-        val EXPECTED_RESULT = true
+        val expectedResult = true
         var actualResult = false
         view.editText?.imeOptions = EditorInfo.IME_ACTION_DONE
-        view.setOnEditorActionDone { actualResult = EXPECTED_RESULT }
+        view.setOnEditorActionDone { actualResult = expectedResult }
         view.editText?.onEditorAction(EditorInfo.IME_ACTION_DONE)
-        assertEquals(EXPECTED_RESULT, actualResult)
+        assertEquals(expectedResult, actualResult)
     }
 }

--- a/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
+++ b/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
@@ -109,7 +109,7 @@ class EmeraldEditTextTest {
     }
 
     @Test
-    fun testNotRd() {
+    fun testOnEditActionDoneMethod() {
         var x = 0
         view.editText?.imeOptions = EditorInfo.IME_ACTION_DONE
         view.setOnEditorActionDone { x = 1 }

--- a/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
+++ b/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
@@ -110,10 +110,10 @@ class EmeraldEditTextTest {
 
     @Test
     fun testOnEditActionDoneMethod() {
-        var x = 0
+        var shouldBeOne = 0
         view.editText?.imeOptions = EditorInfo.IME_ACTION_DONE
-        view.setOnEditorActionDone { x = 1 }
+        view.setOnEditorActionDone { shouldBeOne = 1 }
         view.editText?.onEditorAction(EditorInfo.IME_ACTION_DONE)
-        assertEquals(1, x)
+        assertEquals(1, shouldBeOne)
     }
 }

--- a/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
+++ b/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/EmeraldEditTextTest.kt
@@ -110,11 +110,11 @@ class EmeraldEditTextTest {
 
     @Test
     fun testOnEditActionDoneMethod() {
-        val expectedResult = true
+        val EXPECTED_RESULT = true
         var actualResult = false
         view.editText?.imeOptions = EditorInfo.IME_ACTION_DONE
-        view.setOnEditorActionDone { actualResult = expectedResult }
+        view.setOnEditorActionDone { actualResult = EXPECTED_RESULT }
         view.editText?.onEditorAction(EditorInfo.IME_ACTION_DONE)
-        assertEquals(expectedResult, actualResult)
+        assertEquals(EXPECTED_RESULT, actualResult)
     }
 }


### PR DESCRIPTION
#### What this PR does?
fixes #20 
Adds a method that enables an action when the confirm keyboard button is pressed while typing inside the edit text

#### How should it be manually tested?
Run sample app, go to Emerald Edit Text activity, open keyboard by clicking in the second edit text and press the done button.