### PR TITLE
Hotfix/v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.3.1 - 2018-11-27
+- Fix label background and border colors when no other color is being set
+
 ## 0.3.0 - 2018-11-06
 - [Add emerald colors][issue-25]
 - New label component

--- a/emeraldcomponents/build.gradle
+++ b/emeraldcomponents/build.gradle
@@ -15,7 +15,7 @@ def deployKey = System.env.PACKAGECLOUD_TOKEN != null ? System.env.PACKAGECLOUD_
 def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', '**/*$*', 'android/**/*.*', '**/*Function*', '**/*_impl*']
 def debugTree = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/debug", excludes: fileFilter)
 def mainSrc = "$project.projectDir/src/main/kotlin"
-def version = '0.3.0'
+def version = '0.3.1'
 
 android {
     compileSdkVersion 27

--- a/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/label/EmeraldLabelState.kt
+++ b/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/label/EmeraldLabelState.kt
@@ -4,6 +4,7 @@ import android.graphics.PorterDuff
 import android.graphics.drawable.GradientDrawable
 import android.support.v4.content.ContextCompat
 import br.com.stone.emeraldcomponents.R
+import br.com.stone.emeraldcomponents.extension.colorRes
 import br.com.stone.emeraldcomponents.extension.dimen
 import br.com.stone.emeraldcomponents.extension.show
 import kotlinx.android.synthetic.main.widget_emerald_label.view.*
@@ -18,7 +19,11 @@ enum class EmeraldLabelState : LabelStateHandler {
         override fun setProperties(label: EmeraldLabel, color: Int) {
             label.emeraldLabelText.run {
                 setTextColor(ContextCompat.getColor(context, R.color.emerald_white_1))
-                getLabelBackgroundDrawable(label)?.setColor(color)
+                getLabelBackgroundDrawable(label)?.apply {
+                    setColor(color)
+                    setStroke(context.dimen(R.dimen.label_border_width).toInt(),
+                            context.colorRes(android.R.color.transparent))
+                }
             }
         }
     },
@@ -26,7 +31,10 @@ enum class EmeraldLabelState : LabelStateHandler {
         override fun setProperties(label: EmeraldLabel, color: Int) {
             label.emeraldLabelText.run {
                 setTextColor(color)
-                getLabelBackgroundDrawable(label)?.setStroke(context.dimen(R.dimen.label_border_width).toInt(), color)
+                getLabelBackgroundDrawable(label)?.apply {
+                    setColor(context.colorRes(android.R.color.transparent))
+                    setStroke(context.dimen(R.dimen.label_border_width).toInt(), color)
+                }
             }
         }
     },
@@ -34,6 +42,11 @@ enum class EmeraldLabelState : LabelStateHandler {
         override fun setProperties(label: EmeraldLabel, color: Int) {
             label.run {
                 emeraldLabelText.setTextColor(color)
+                getLabelBackgroundDrawable(label)?.apply {
+                    setStroke(context.dimen(R.dimen.label_border_width).toInt(),
+                            context.colorRes(android.R.color.transparent))
+                    setColor(context.colorRes(android.R.color.transparent))
+                }
                 val drawable = ContextCompat.getDrawable(context, R.drawable.dot_shape)?.mutate()
                 drawable?.setColorFilter(color, PorterDuff.Mode.SRC_IN)
                 emeraldLabelImage.setImageDrawable(drawable)


### PR DESCRIPTION
#### What this PR does?
Fixes a bug that when the label had properties being set in xml and then in kotlin, the colors would get mixed

(The INFO label from preenchido section is green)
![image](https://user-images.githubusercontent.com/21258742/49115190-3e9d4f80-f281-11e8-8225-d17765910687.png)

#### How should it be manually tested?
Use the method ```setProperties()``` to change the properties from a label and run sample app's activity. If the colors are correct, it worked.