### PR TITLE
Updated coveralls version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.3.0-alpha08'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.jacoco:org.jacoco.core:0.8.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:1.0.2'
+        classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2"
         classpath 'com.karumi:shot:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
#### What this PR does?
Update coveralls version number to avoid `Could not find any version that matches com.android.tools.build:gradle:0.11.+` error
