### PR TITLE
Fix NumberFormatException on EmeraldMaskedEditText 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.3.3 - 2018-12-10
 
+### Fixed
+- [NumberFormatException on EmeraldMaskedEditText][issue-58]
+
+## 0.3.3 - 2018-12-10
+
 ### Modified
 - [Added button customizations][issue-52]
 
@@ -63,4 +68,5 @@
 [issue-34]:https://github.com/stone-payments/emerald-components-android/issues/34
 [issue-25]:https://github.com/stone-payments/emerald-components-android/issues/25
 [issue-52]:https://github.com/stone-payments/emerald-components-android/issues/52
+[issue-58]:https://github.com/stone-payments/emerald-components-android/issues/58
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.3.3 - 2018-12-10
+## UNRELEASED
 
 ### Fixed
 - [NumberFormatException on EmeraldMaskedEditText][issue-58]

--- a/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/input/CurrencyTextWatcher.kt
+++ b/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/input/CurrencyTextWatcher.kt
@@ -16,7 +16,7 @@ class CurrencyTextWatcher(val editText: EditText,
                           private val valueListener: (unmaskedText: String) -> Unit = {}) : TextWatcher {
 
     private val numberFormat = NumberFormat.getCurrencyInstance(locale)
-    private val replaceable = "[${numberFormat.currency.symbol},.]"
+    private val replaceable = "\\D"
 
     override fun afterTextChanged(text: Editable?) {
         editText.removeTextChangedListener(this)

--- a/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/CurrencyTextWatcherTest.kt
+++ b/emeraldcomponents/src/test/java/br/com/stone/emeraldcomponents/basics/input/CurrencyTextWatcherTest.kt
@@ -26,33 +26,42 @@ class CurrencyTextWatcherTest {
     @Before
     fun setup() {
         editText = EditText(RuntimeEnvironment.application)
-        textWatcher = CurrencyTextWatcher(editText)
+        textWatcher = CurrencyTextWatcher(editText, Locale("pt", "BR"))
     }
 
     @Test
-    fun testLocaleBrazilCurrencyFormat() {
-        val textWatcher = CurrencyTextWatcher(editText, Locale("pt", "BR"))
+    fun testDefaultLocale() {
+        val textWatcher = CurrencyTextWatcher(editText)
         textWatcher.afterTextChanged(SpannableStringBuilder("100"))
-        assertEquals("R$ 1,00", editText.text.toString())
+        assertEquals('0', editText.text.last())
     }
 
     @Test
-    fun testLocaleBrazilCurrencyInvalidFormat() {
-        val textWatcher = CurrencyTextWatcher(editText, Locale("pt", "BR"))
+    fun testDefaultLocaleInvalidFormat() {
+        val textWatcher = CurrencyTextWatcher(editText)
         textWatcher.afterTextChanged(SpannableStringBuilder(""))
-        assertEquals("R$ 0,00", editText.text.toString())
+        assertEquals('0', editText.text.last())
     }
 
     @Test
     fun testAfterTextChanged() {
+        textWatcher = CurrencyTextWatcher(editText, Locale("pt", "BR"))
         textWatcher.afterTextChanged(SpannableStringBuilder("1"))
-        assertEquals('1', editText.text.last())
+        assertEquals("R$ 0,01", editText.text.toString())
+    }
+
+    @Test
+    fun testAfterTextChangedWithInvalidNumber() {
+        textWatcher = CurrencyTextWatcher(editText, Locale("pt", "BR"))
+        textWatcher.afterTextChanged(SpannableStringBuilder("invalid"))
+        assertEquals("R$ 0,00", editText.text.toString())
     }
 
     @Test
     fun testAfterTextChangedWithMaximumLength() {
+        textWatcher = CurrencyTextWatcher(editText, Locale("pt", "BR"))
         textWatcher.afterTextChanged(SpannableStringBuilder("111111111111111111"))
-        assertEquals('1', editText.text.last())
+        assertEquals("R$ 111.111.111.111,11", editText.text.toString())
     }
 
     @Test


### PR DESCRIPTION
#### What this PR does?
Fix #58 

#### How should it be manually tested?
Run inputs example activity and use the currency mask