### PR TITLE
Fix crash on EmeraldEditText Password toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - [NumberFormatException on EmeraldMaskedEditText][issue-58]
+- [Fix crash on EmeraldEditText Password toggle][issue-60]
+
 
 ### Modified
 - [Changed primary color from #95C93D to #0DB14B][issue-61]
@@ -73,4 +75,5 @@
 [issue-52]:https://github.com/stone-payments/emerald-components-android/issues/52
 [issue-58]:https://github.com/stone-payments/emerald-components-android/issues/58
 [issue-61]:https://github.com/stone-payments/emerald-components-android/issues/61
+[issue-61]:https://github.com/stone-payments/emerald-components-android/issues/60
 

--- a/app/src/androidTest/java/br/com/stone/emeraldcomponentsandroid/activities/InputActivityTest.kt
+++ b/app/src/androidTest/java/br/com/stone/emeraldcomponentsandroid/activities/InputActivityTest.kt
@@ -183,7 +183,5 @@ class InputActivityTest : BaseScreenshotTest() {
 
         activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
         activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-
-        screenShot("password-edittext")
     }
 }

--- a/app/src/androidTest/java/br/com/stone/emeraldcomponentsandroid/activities/InputActivityTest.kt
+++ b/app/src/androidTest/java/br/com/stone/emeraldcomponentsandroid/activities/InputActivityTest.kt
@@ -1,5 +1,6 @@
 package br.com.stone.emeraldcomponentsandroid.activities
 
+import android.content.pm.ActivityInfo
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.action.ViewActions.clearText
 import android.support.test.espresso.action.ViewActions.click
@@ -30,7 +31,7 @@ import java.util.Locale
  * Copyright (c) Stone Co. All rights reserved.
  * lucas.amaral@stone.com.br
  */
-class InputActivityTest: BaseScreenshotTest() {
+class InputActivityTest : BaseScreenshotTest() {
 
     override val activity: AppCompatActivity
         get() = activityRule.activity
@@ -172,5 +173,17 @@ class InputActivityTest: BaseScreenshotTest() {
                 .check(matches(withText("21000-000")))
 
         screenShot("cep-edittext")
+    }
+
+
+    @Test
+    fun shouldPasswordEditNotCrashWhenToggleIsClickedAndOrientationChanges(){
+        onView(withId((R.id.text_input_password_toggle)))
+                .perform(click())
+
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+
+        screenShot("password-edittext")
     }
 }

--- a/app/src/main/res/layout/activity_input.xml
+++ b/app/src/main/res/layout/activity_input.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -24,6 +23,21 @@
             app:required="true" />
 
         <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
+            android:id="@+id/passwordEditText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:hint="Password"
+            android:inputType="textPassword"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/emeraldEditText"
+            app:passwordToggleEnabled="true"
+            />
+
+        <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
             android:id="@+id/cellPhoneEditText"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -33,8 +47,8 @@
             android:hint="Cell Phone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/emeraldEditText"
-            app:maskType="cellphoneNumber"/>
+            app:layout_constraintTop_toBottomOf="@id/passwordEditText"
+            app:maskType="cellphoneNumber" />
 
         <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
             android:id="@+id/phoneEditText"
@@ -47,7 +61,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/cellPhoneEditText"
-            app:maskType="phoneNumber"/>
+            app:maskType="phoneNumber" />
 
         <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
             android:id="@+id/cnpjEditText"
@@ -60,7 +74,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/phoneEditText"
-            app:maskType="cnpj"/>
+            app:maskType="cnpj" />
 
         <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
             android:id="@+id/cpfEditText"
@@ -73,7 +87,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/cnpjEditText"
-            app:maskType="cpf"/>
+            app:maskType="cpf" />
 
         <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
             android:id="@+id/currencyEditText"
@@ -85,7 +99,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/cpfEditText"
-            app:maskType="currency"/>
+            app:maskType="currency" />
 
         <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
             android:id="@+id/emailEditText"
@@ -98,7 +112,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/currencyEditText"
-            app:maskType="email"/>
+            app:maskType="email" />
 
         <br.com.stone.emeraldcomponents.basic.input.EmeraldEditText
             android:id="@+id/cepEditText"

--- a/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/input/EmeraldEditText.kt
+++ b/emeraldcomponents/src/main/java/br/com/stone/emeraldcomponents/basic/input/EmeraldEditText.kt
@@ -2,6 +2,7 @@ package br.com.stone.emeraldcomponents.basic.input
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.EditText
 import br.com.stone.emeraldcomponents.R
 import kotlinx.android.synthetic.main.widget_edittextview.view.*
 
@@ -22,9 +23,10 @@ class EmeraldEditText : EmeraldBaseEditText {
     }
 
     init {
-        addView(inflate(context, R.layout.widget_edittextview, null))
-        editText?.inputType = inputType
-        editText?.setText(textAttribute)
+        val editText = inflate(context, R.layout.widget_edittextview, null) as EditText
+        editText.inputType = inputType
+        editText.setText(textAttribute)
+        addView(editText)
     }
 
     fun setMaskType(type: EmeraldMaskedEditText.MaskTypes) {


### PR DESCRIPTION
#### What this PR does?
fix #60 

#### How should it be manually tested?
Open input activity
click the password toggle
rotate the device

or

run the `shouldPasswordEditNotCrashWhenToggleIsClickedAndOrientationChanges` instrumented test